### PR TITLE
Return empty optional when there is no capability for a null ordinal

### DIFF
--- a/src/main/java/com/flansmod/common/crafting/WorkbenchBlockEntity.java
+++ b/src/main/java/com/flansmod/common/crafting/WorkbenchBlockEntity.java
@@ -364,6 +364,10 @@ public class WorkbenchBlockEntity extends BlockEntity implements WorldlyContaine
 	@Nonnull
 	public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, Direction side)
 	{
+		if (side == null)
+		{
+			return LazyOptional.empty();
+		}
 		if (cap == ForgeCapabilities.ITEM_HANDLER)
 		{
 			LazyOptional<IItemHandler> lazyOptional = DirectionalItemCapLazyOptionals.get(side.ordinal());


### PR DESCRIPTION
As the title says.

This specifically fixes a crash with Ars Nouveau, as the scribe workbench will crash a server if it is near a gun workbench while attempting to search and use items to make a glyph with.


Sidenote: Following the steps to compile the mod (even in the unmodified current branch) creates an unusable jar that crashes on startup due to a NoSuchFieldError "CREATIVE_MODE_TAB" unless it's a deobfuscated jar.
Not sure if this is due to a build config that gets changed when not using the main repo?